### PR TITLE
Abort energy transfer if harvester is facing up or down

### DIFF
--- a/src/main/java/io/moonman/emergingtechnology/machines/harvester/HarvesterTileEntity.java
+++ b/src/main/java/io/moonman/emergingtechnology/machines/harvester/HarvesterTileEntity.java
@@ -343,6 +343,11 @@ public class HarvesterTileEntity extends MachineTileBase implements ITickable, S
             // Get the direction this harvester is facing
             EnumFacing facing = this.world.getBlockState(this.pos).getValue(Harvester.FACING);
 
+            // Abort if facing up or down
+            if (facing == EnumFacing.UP || facing == EnumFacing.DOWN) {
+                return;
+            }
+
             // Get the left side of the harvester
             EnumFacing left = facing.rotateYCCW();
 


### PR DESCRIPTION
Resolves #48 

Not a lot you can accurately do to find out the "left" face if it's pointing up or down, so I felt it was safer to just abort.  If you'd prefer, we can use a default direction instead.